### PR TITLE
Fix update emit target

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -25,13 +25,13 @@ export class Server {
 
         socket.emit("update", await controller.get());
         socket.on("get", async () => {
-          socket.emit("update", await controller.get());
+          counterNamespace.emit("update", await controller.get());
         });
         socket.on("patch", async (delta: number) => {
-          socket.emit("update", await controller.patch(delta));
+          counterNamespace.emit("update", await controller.patch(delta));
         });
         socket.on("delete", async () => {
-          socket.emit("update", await controller.delete());
+          counterNamespace.emit("update", await controller.delete());
         });
       });
 


### PR DESCRIPTION
Previously, we emit update event to `socket`, so update event only fired on client that fires get, patch and delete event.
This is not expected behavior, because other clients doesn't update their state real-timely.